### PR TITLE
chore(MOS-855): Add PHP 8.2 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
             -   uses: actions/checkout@v3
             -   uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.1
+                    php-version: 8.2
                     coverage: none
             -   uses: ramsey/composer-install@v2
             -   id: set-php-versions

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/process": "^5.4 || ^6.0"
     },
     "require-dev": {
-        "myonlinestore/coding-standard": "dev-doctrine-cs-10",
+        "myonlinestore/coding-standard": "^4.0",
         "doctrine/coding-standard": "10.0.x-dev",
         "phpunit/phpunit": "^9.5",
         "roave/infection-static-analysis-plugin": "^1.19",

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -10,19 +10,19 @@ use Symfony\Component\Process\Process;
 final class Configuration
 {
     private const PHP_VERSIONS = [
-        '8.0',
         '8.1',
+        '8.2',
     ];
 
     /** @var array<string, class-string<DevToolsCommand>>|null */
-    private array|null $enabledTools = null;
+    private array | null $enabledTools = null;
 
     /** @var list<string>|null */
-    private array|null $phpVersions = null;
+    private array | null $phpVersions = null;
 
     private string $rootDir;
-    private string|null $workingDir = null;
-    private string|null $threads = null;
+    private string | null $workingDir = null;
+    private string | null $threads = null;
 
     public function __construct()
     {


### PR DESCRIPTION
Changes:
- Added `8.2` to list of PHP versions that devtools should be executed for (is used to construct a version matrix in CI of other projects)
- Updated `myonlinestore/coding-standard` to latest version, which was still pinned to a no longer existing branch.

**Don't forget to add a new `0.4` tag after merging, so the new version can be accurately pinned in other projects.**