### PR TITLE
chore(MOS-1820): Add PHP 8.3 support.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
             -   uses: actions/checkout@v3
             -   uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.2
+                    php-version: 8.3
                     coverage: none
             -   uses: ramsey/composer-install@v2
             -   id: set-php-versions

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "phpunit/phpunit": "^9.5",
         "roave/infection-static-analysis-plugin": "^1.19",
         "roave/security-advisories": "dev-latest",
-        "vimeo/psalm": "^4.23",
+        "vimeo/psalm": "^5.0",
         "phpstan/phpstan": "^1.7",
         "phpstan/phpstan-phpunit": "^1.1",
         "phparkitect/phparkitect": "^0.2.21"

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -12,6 +12,7 @@ final class Configuration
     private const PHP_VERSIONS = [
         '8.1',
         '8.2',
+        '8.3',
     ];
 
     /** @var array<string, class-string<DevToolsCommand>>|null */


### PR DESCRIPTION
## 💅🏻  Aftercare
- [ ] Create a new `0.5` tag.

## 🌟 Summary.
This pull request adds PHP 8.3 support.

## 📝 Changelog.
- Updated GitHub workflow PHP version.
- Added `8.3` to supported PHP versions in `Configuration`.
- Updated `vimeo/psalm` to `^5.0`.